### PR TITLE
Clear last hint on restart

### DIFF
--- a/test_game_ver2.py
+++ b/test_game_ver2.py
@@ -6,6 +6,7 @@ def initialize_game():
     st.session_state.secret_number = random.randint(1, 100)
     st.session_state.attempts = 0
     st.session_state.game_over = False
+    st.session_state.pop("last_hint", None)
     st.session_state.guesses = []
 
 def check_guess():


### PR DESCRIPTION
## Summary
- clear `last_hint` when initializing the game

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_683fa936311c832a84adaef311193bab